### PR TITLE
Fix build fail on MacOs 🍎

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         node-version: [10.x, 12.x]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v1

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,6 +15,13 @@
         'dependencies': [
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
-        'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
+        'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+        'conditions': [
+            ['OS=="mac"', {
+                'xcode_settings': {
+                    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                }
+            }]
+        ],
     }]
 }


### PR DESCRIPTION
Update binding.gyp in order to fix node-gyp build on MacOs.

Related Issue:
https://github.com/nodejs/node-gyp/issues/17#issuecomment-3917672